### PR TITLE
Update VeUnoDaoYieldDistributor.sol: Usage of 'internal' function for modifier

### DIFF
--- a/contracts/apps/VeUnoDaoYieldDistributor.sol
+++ b/contracts/apps/VeUnoDaoYieldDistributor.sol
@@ -63,10 +63,7 @@ contract VeUnoDaoYieldDistributor is OwnedUpgradeable, ReentrancyGuardUpgradeabl
     event RecoveredERC20(address token, uint256 amount);
 
     modifier onlyByOwnGov() {
-        require(
-            msg.sender == owner || msg.sender == timelock,
-            "VeUnoYD: !O/T"
-        );
+        _onlyByOwnGov();
         _;
     }
 
@@ -88,6 +85,14 @@ contract VeUnoDaoYieldDistributor is OwnedUpgradeable, ReentrancyGuardUpgradeabl
         rewardNotifiers[msg.sender] = true;
         yieldDuration = 604800; // 7 * 86400  (7 days)
         __Owned_init(_owner);
+    }
+
+    // Internal function to be used for modifier 'onlyByOwnGov'
+    function _onlyByOwnGov() internal view {
+        require(
+            msg.sender == owner || msg.sender == timelock,
+            "VeUnoYD: !O/T"
+        );
     }
 
     function sync() public {


### PR DESCRIPTION
Here, the internal function used for modifier 'onlyByOwnGov' do saves some gas.

These links will help:
- https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#use-internal-view-functions-in-modifiers-to-save-bytecode
- https://www.rareskills.io/post/gas-optimization#viewer-527f6
- Seems to be a worthy discussion -- https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3347/

Thanks!